### PR TITLE
Add Health Check Endpoint to kafka-retryable-consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src=".readme/logo-color.svg" alt="KafkaRertryableConsumer"/>
+<img src=".readme/logo-color.svg" alt="KafkaRetryableConsumer"/>
 
 # Kafka Retryable Consumer
 
@@ -19,45 +19,122 @@ This lib is proposed to ease the usage of kafka for simple data consumer with ex
 </div>
 
 ## Table of Contents
-* [Features](#features)
-    * [Current version](#current-version)
-    * [To be implemented](#to-be-implemented)
-* [Getting Started](#getting-started)
-    * [Vanilla Java](#vanilla-java)
-    * [Springboot](#springboot)
-* [Configuration](#configuration)
-* [Customisation](#customization)
-    * [Dead Letter Queue (DLQ)](#dead-letter-queue-dlq)
-    * [Custom Error Processing](#custom-error-processing)
-* [Code References](#code-references)
+- [Features](#features)
+- [Getting Started](#getting-started)
+- [Health Checks](#health-checks)
+- [Configuration](#configuration)
+- [Customization](#customization)
+- [Contribution & Development](#contribution--development)
+- [License](#license)
 
 ## Features
-### Current version
 - Error management with Dead Letter Queue
 - Automatic record commit management in case of error or partition rebalance
 - Retry on error with Exception exclusion management
 - Custom Error processing
 - Batch Record Processing
+- **Kubernetes-style health check endpoints** (core & Spring Boot)
 
-### To be implemented
-- Health checks in core library for non springboot projects
+## Getting Started
+This repository hosts libraries for building robust Kafka consumers with retry and health check support.
+- **retryable-consumer-core**: Core library for Java
+- **retryable-consumer-spring-boot-starter**: Spring Boot autoconfiguration
 
-## Getting started
-Kafka consumer libs repository hosts various libraries that might be usefull for your Kafka project.
-- retryable-consumer-core : Core library for easy retryable consumers implementation
-- retryable-consumer-springboot-starter : Spring Boot autoconfiguration for the Retryable Consumer core library
-### Vanilla Java
-
-Insert retryable-consumer-core dependency in your POM :
-```xml  
-<dependency>  
-    <groupId>com.michelin.kafka</groupId>    
-    <artifactId>retryable-consumer-core</artifactId>    
+### Vanilla Java Example
+Add to your POM:
+```xml
+<dependency>
+    <groupId>com.michelin.kafka</groupId>
+    <artifactId>retryable-consumer-core</artifactId>
     <version>${retryable-consumer-core.version}</version>
-</dependency>  
-```  
+</dependency>
+```
 
-Then in your code, on a retryable consumer just call ```java listen(topics)``` method :
+Basic usage:
+```java
+try(RetryableConsumer<String, String> retryableConsumer = new RetryableConsumer<>()) {
+    retryableConsumer.listen(
+        Collections.singleton("MY_TOPIC"),
+        businessProcessor::processRecord
+    );
+}
+```
+
+### Spring Boot Example
+Add the starter:
+```xml
+<dependency>
+  <groupId>com.michelin.kafka</groupId>
+  <artifactId>retryable-consumer-spring-boot-starter</artifactId>
+  <version>${retryable-consumer-core.version}</version>
+</dependency>
+```
+
+Minimal `application.yml`:
+```yaml
+kafka:
+  retryable:
+    enabled: true
+    consumer:
+      topics:
+        - my-topic
+      properties:
+        bootstrap.servers: 127.0.0.1:9092
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+```
+
+Inject and use:
+```java
+@Autowired
+private RetryableConsumer<String, String> retryableConsumer;
+```
+
+## Health Checks
+
+Both core and Spring Boot modules expose **Kubernetes-style health endpoints** for readiness and liveness probes.
+
+- **Spring Boot**: Endpoints are available if `spring-boot-starter-web` is present.
+    - `GET /ready` (readiness)
+    - `GET /liveness` (liveness)
+    - Paths configurable via `kubernetes.readiness.path` and `kubernetes.liveness.path`
+- **Core**: Use `KubernetesService` to get readiness/liveness status codes for embedding in your own HTTP server.
+
+| State      | Readiness | Liveness |
+|------------|-----------|----------|
+| RUNNING    | 200       | 200      |
+| STARTING   | 204       | 200      |
+| ERROR      | 503       | 503      |
+| STOPPED    | 503       | 503      |
+| null       | 400       | 204      |
+
+## Configuration
+See [Spring Boot README](retryable-consumer-spring-boot-starter/README.md) for full property reference.
+
+## Customization
+- **Dead Letter Queue (DLQ)**: Optional, configure `kafka.retryable.dead-letter.producer.topic` and properties.
+- **Custom Error Processing**: Implement `ErrorProcessor` and inject into your consumer.
+
+## Contribution & Development
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+- Run all tests:
+```bash
+mvn clean test
+```
+- Format code:
+```bash
+mvn spotless:apply
+```
+
+## License
+
+This project is licensed under the [Apache 2.0 License](LICENSE).
+
+---
+
+Original inspiration: [kstreamplify](https://github.com/michelin/kstreamplify)
+
 ```java  
 try(RetryableConsumer<String, String> retryableConsumer = new RetryableConsumer<>()) {
     retryableConsumer.listen(

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+﻿<div align="center">
 
 <img src=".readme/logo-color.svg" alt="KafkaRetryableConsumer"/>
 
@@ -11,37 +11,52 @@
 [![SonarCloud Tests](https://img.shields.io/sonar/tests/michelin_kafka-retryable-consumer/main?server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge&logo=sonarcloud)](https://sonarcloud.io/component_measures?metric=tests&view=list&id=michelin_kafka-retryable-consumer)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?logo=apache&style=for-the-badge)](https://opensource.org/licenses/Apache-2.0)
 
-Simple Kafka consumer library with retry capabilities.
-
-Retryable Consumer Libraries, allow you to easily build a Kafka API consumer with retry capabilities.
-This lib is proposed to ease the usage of kafka for simple data consumer with external system call.
+A simple, robust Kafka consumer library with built-in retry, dead letter queue, and Kubernetes health check support.
 
 </div>
 
 ## Table of Contents
+
 - [Features](#features)
+- [Modules](#modules)
 - [Getting Started](#getting-started)
-- [Health Checks](#health-checks)
+  - [Vanilla Java](#vanilla-java)
+  - [Spring Boot](#spring-boot)
 - [Configuration](#configuration)
+  - [Consumer Properties](#consumer-properties)
+  - [Dead Letter Producer Properties](#dead-letter-producer-properties)
+  - [Health Check Properties](#health-check-properties)
+- [Health Checks](#health-checks)
 - [Customization](#customization)
+  - [Dead Letter Queue (DLQ)](#dead-letter-queue-dlq)
+  - [Custom Error Processing](#custom-error-processing)
 - [Contribution & Development](#contribution--development)
 - [License](#license)
+- [Credits](#credits)
 
 ## Features
-- Error management with Dead Letter Queue
-- Automatic record commit management in case of error or partition rebalance
-- Retry on error with Exception exclusion management
-- Custom Error processing
-- Batch Record Processing
-- **Kubernetes-style health check endpoints** (core & Spring Boot)
+
+- **Retry on error** with configurable max retries, backoff, and exception exclusion
+- **Dead Letter Queue (DLQ)** for unrecoverable records
+- **Automatic commit management** on error or partition rebalance
+- **Batch record processing**
+- **Custom error processing** via the `ErrorProcessor` interface
+- **Kubernetes health checks** — readiness and liveness endpoints (core & Spring Boot)
+- **Blocking and non-blocking** consumption (`listen()` / `listenAsync()`)
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| [retryable-consumer-core](retryable-consumer-core/) | Core Java library — no framework dependency |
+| [retryable-consumer-spring-boot-starter](retryable-consumer-spring-boot-starter/) | Spring Boot autoconfiguration & health endpoints |
 
 ## Getting Started
-This repository hosts libraries for building robust Kafka consumers with retry and health check support.
-- **retryable-consumer-core**: Core library for Java
-- **retryable-consumer-spring-boot-starter**: Spring Boot autoconfiguration
 
-### Vanilla Java Example
-Add to your POM:
+### Vanilla Java
+
+Add the core dependency:
+
 ```xml
 <dependency>
     <groupId>com.michelin.kafka</groupId>
@@ -50,9 +65,10 @@ Add to your POM:
 </dependency>
 ```
 
-Basic usage:
+Create a consumer and start listening:
+
 ```java
-try(RetryableConsumer<String, String> retryableConsumer = new RetryableConsumer<>()) {
+try (RetryableConsumer<String, String> retryableConsumer = new RetryableConsumer<>()) {
     retryableConsumer.listen(
         Collections.singleton("MY_TOPIC"),
         businessProcessor::processRecord
@@ -60,17 +76,54 @@ try(RetryableConsumer<String, String> retryableConsumer = new RetryableConsumer<
 }
 ```
 
-### Spring Boot Example
-Add the starter:
+> **Note:** `businessProcessor` must have a method accepting a `ConsumerRecord<K, V>` as input.
+
+> **Warning:** `listen()` is a blocking call that starts an endless polling loop.
+> For non-blocking consumption, use `listenAsync()` which returns a `Future`.
+
+The consumer loads its configuration from `application.yml`, `application.yaml`, or `application.properties`:
+
+```yaml
+kafka:
+  retryable:
+    name: my-retryable-consumer
+    consumer:
+      topics: MY_TOPIC
+      stop-on-error: false
+      not-retryable-exceptions:
+        - java.lang.NullPointerException
+        - java.lang.IllegalArgumentException
+      retry:
+        max: 10
+      poll:
+        backoff:
+          ms: 2000
+      properties:
+        application.id: retryable-consumer-app
+        bootstrap.servers: localhost:9092
+        specific.avro.reader: true
+    dead-letter:
+      producer:
+        topic: DL_TOPIC
+        properties:
+          application.id: dl-producer-app
+          bootstrap.servers: localhost:9092
+```
+
+### Spring Boot
+
+Add the starter dependency:
+
 ```xml
 <dependency>
-  <groupId>com.michelin.kafka</groupId>
-  <artifactId>retryable-consumer-spring-boot-starter</artifactId>
-  <version>${retryable-consumer-core.version}</version>
+    <groupId>com.michelin.kafka</groupId>
+    <artifactId>retryable-consumer-spring-boot-starter</artifactId>
+    <version>${retryable-consumer-core.version}</version>
 </dependency>
 ```
 
-Minimal `application.yml`:
+Configure `application.yml`:
+
 ```yaml
 kafka:
   retryable:
@@ -79,224 +132,76 @@ kafka:
       topics:
         - my-topic
       properties:
-        bootstrap.servers: 127.0.0.1:9092
+        bootstrap.servers: localhost:9092
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 ```
 
 Inject and use:
+
 ```java
 @Autowired
 private RetryableConsumer<String, String> retryableConsumer;
 ```
+
+For advanced usage (custom beans, error handling, testing), see the [Spring Boot Starter README](retryable-consumer-spring-boot-starter/README.md).
+
+## Configuration
+
+### Consumer Properties
+
+Configuration prefix: `kafka.retryable`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Toggle auto-configuration on/off (Spring Boot only) |
+| `consumer.topics` | Collection\<String\> | — | Input topic list (**required**) |
+| `consumer.properties` | Properties | — | Standard Kafka consumer properties (`bootstrap.servers`, etc.) |
+| `consumer.poll-backoff-ms` | Long | `1000` | Poll timeout in milliseconds |
+| `consumer.retry-backoff-ms` | Long | `0` | Backoff between retries in milliseconds |
+| `consumer.retry-max` | Long | `0` | Max retry count (`0` = infinite) |
+| `consumer.not-retryable-exceptions` | Collection\<String\> | `[]` | Exceptions that skip retry |
+| `consumer.stop-on-error` | boolean | `false` | Stop consumer entirely on non-retryable error |
+
+### Dead Letter Producer Properties
+
+Configuration prefix: `kafka.retryable.dead-letter.producer`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `topic` | String | — | DLQ topic name |
+| `properties` | Properties | — | Standard Kafka producer properties (`bootstrap.servers`, serializers, etc.) |
+
+### Health Check Properties
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `kubernetes.readiness.path` | String | `ready` | Readiness endpoint path |
+| `kubernetes.liveness.path` | String | `liveness` | Liveness endpoint path |
 
 ## Health Checks
 
-Both core and Spring Boot modules expose **Kubernetes-style health endpoints** for readiness and liveness probes.
+The library tracks consumer lifecycle state (`STARTING` -> `RUNNING` -> `ERROR` / `STOPPED`) and exposes Kubernetes-compatible health endpoints.
 
-- **Spring Boot**: Endpoints are available if `spring-boot-starter-web` is present.
-    - `GET /ready` (readiness)
-    - `GET /liveness` (liveness)
-    - Paths configurable via `kubernetes.readiness.path` and `kubernetes.liveness.path`
-- **Core**: Use `KubernetesService` to get readiness/liveness status codes for embedding in your own HTTP server.
+**Spring Boot** — If `spring-boot-starter-web` is on the classpath, endpoints are auto-configured:
+- `GET /{kubernetes.readiness.path}` (default: `/ready`)
+- `GET /{kubernetes.liveness.path}` (default: `/liveness`)
 
-| State      | Readiness | Liveness |
-|------------|-----------|----------|
-| RUNNING    | 200       | 200      |
-| STARTING   | 204       | 200      |
-| ERROR      | 503       | 503      |
-| STOPPED    | 503       | 503      |
-| null       | 400       | 204      |
+**Core (Vanilla Java)** — Use `KubernetesService` directly to query health status and integrate with your own HTTP server.
 
-## Configuration
-See [Spring Boot README](retryable-consumer-spring-boot-starter/README.md) for full property reference.
+| Consumer State | Readiness | Liveness |
+|----------------|-----------|----------|
+| `RUNNING`    | 200 OK    | 200 OK   |
+| `STARTING`   | 204 No Content | 200 OK |
+| `ERROR`      | 503 Unavailable | 503 Unavailable |
+| `STOPPED`    | 503 Unavailable | 503 Unavailable |
+| `null` (no consumer) | 400 Bad Request | 204 No Content |
 
 ## Customization
-- **Dead Letter Queue (DLQ)**: Optional, configure `kafka.retryable.dead-letter.producer.topic` and properties.
-- **Custom Error Processing**: Implement `ErrorProcessor` and inject into your consumer.
 
-## Contribution & Development
-See [CONTRIBUTING.md](CONTRIBUTING.md).
-
-- Run all tests:
-```bash
-mvn clean test
-```
-- Format code:
-```bash
-mvn spotless:apply
-```
-
-## License
-
-This project is licensed under the [Apache 2.0 License](LICENSE).
-
----
-
-Original inspiration: [kstreamplify](https://github.com/michelin/kstreamplify)
-
-```java  
-try(RetryableConsumer<String, String> retryableConsumer = new RetryableConsumer<>()) {
-    retryableConsumer.listen(
-        Collections.singleton("MY_TOPIC"), //Topic name
-        businessProcessor::processRecord //Function process called by RetryableConsumer for each record
-    );
-}
-```  
-`businessProcessor` must be your own processing classe with a method (`processRecord` in this example) accepting one  
-`ConsumerRecord<K, V>` as input.
-
-:warning: ```java listen(topics)``` method is blocker and will start an endless loop to consumer you topic record.  
-If you need a non-blocking method, please use ```java listenAsync(topics)``` that returns a future.
-
-In order to work properly, the retryable consumer will try to load kafka configuration from `application.yml`  
-or `application.yaml` or `application.properties`.
-
-Example of application.yml :
-
-```yaml  
-kafka:
-  retryable:
-    name: test-retry-consumer # name of the retryable consumer
-    consumer: # All retryable consumer properties
-      not-retryable-exceptions: # List of exceptions that will be ignored by the retry mechanism
-        - java.lang.NullPointerException
-        - java.lang.IllegalArgumentException
-      stop-on-error: false # If true, the consumer will completely stop on not retryable error. Default value = false
-      retry: # Retry configuration
-        max: 10 # Maximum number of retry. 0 means infinite retry. Default value = 0
-      poll:
-        backoff:
-          ms: 2345 # The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
-      properties: # All Kafka server configuration, please add your custom kafka consumer config here
-        application:
-          id: retryable-consumer-test
-        bootstrap:
-          servers: fake.server:9092
-        specific:
-          avro:
-            reader: true
-      topics: TOPIC # List of topics to listen to. Not mandatory
-    dead-letter:
-      producer:
-        properties: # All Kafka server configuration for the dlq producer, please add your custom kafka producer config here
-          application:
-            id: dl-producer-test
-          bootstrap:
-            servers: fake.server:9092
-        topic: DL_TOPIC
-```  
-
-## Springboot
-
-Add the starter as a dependency to your Spring Boot application:
-
-```xml
-<dependency>
-  <groupId>com.michelin.kafka</groupId>
-  <artifactId>retryable-consumer-spring-boot-starter</artifactId>
-  <version><!-- project version -->${retryable-consumer-core.version}</version>
-</dependency>
-```
-
-Then configure properties in `application.yml` or `application.properties`.
-
-Example `application.yml` minimal:
-
-```yaml
-kafka:
-  retryable:
-    enabled: true
-    consumer:
-      topics:
-        - my-topic
-      properties:
-        bootstrap.servers: 127.0.0.1:9092
-        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-```
-
-This will create a `RetryableConsumer` bean with default behavior. To inject it into your code:
-
-```java
-@Autowired
-private RetryableConsumer<String, String> retryableConsumer;
-```
-
-Then use `retryableConsumer.listen(...)` or `listenAsync(...)` with a `RecordProcessor`.
-### Advanced usage
-
-- If you want full control over the configuration object, define a `@Bean` of type `KafkaRetryableConfiguration` in your application context — the starter will not override it (it uses `@ConditionalOnMissingBean`).
-- You can also provide `KafkaRetryableSpringProperties` (for binding) instead of `KafkaRetryableConfiguration` and the mapper will convert it.
-
-Example customizing error handling:
-
-```java
-@Bean
-public RetryableConsumer<String, MyValue> customRetryableConsumer(KafkaRetryableConfiguration cfg, DeadLetterProducer dlq) {
-  // build a RetryableConsumer with custom ErrorProcessor or inject the DLQ
-  return new RetryableConsumer<>(cfg, dlq);
-}
-```
-
-### Testing notes
-
-- Unit tests in this module avoid creating real Kafka clients during Spring context refresh. The starter defers Kafka client construction (lazy) and provides defaults for deserializers/serializers in tests to avoid Kafka client ConfigExceptions.
-- For true integration tests against Kafka use `spring-kafka-test`'s `EmbeddedKafkaBroker` (create a separate integration test profile).
-- If tests are flaky due to async background processing, prefer synchronization helpers such as `CountDownLatch` or inject a test Executor.
-
-### Troubleshooting
-
-- Error: "Missing required property: kafka.retryable.consumer.topics must be configured and non-empty"
-    - Ensure `kafka.retryable.consumer.topics` is set in application properties or provide a `KafkaRetryableConfiguration` bean.
-
-- Error: "Missing required property: kafka.retryable.consumer.properties.bootstrap.servers must be configured"
-    - Add `bootstrap.servers` under `kafka.retryable.consumer.properties`.
-
-- If tests fail with Kafka client DNS/connection errors in CI, ensure tests either mock Kafka clients or run integration tests against Embedded Kafka. Unit tests should remain network-free.
-
-## Contribution & Development
-
-- Run unit tests for the starter module:
-
-```bash
-mvn -am -pl retryable-consumer-spring-boot-starter test
-```
-
-- To run core module tests:
-
-```bash
-mvn -pl retryable-consumer-core -Dtest=com.michelin.kafka.test.unit.RetryableConsumerTest test
-```
-
-## Configuration
-
-Configuration key prefix`kafka.retryable` :
-
-| Configuration key                               | Value Type         | Default Value | Description                                                  | Note                                                               |
-|-------------------------------------------------| ------------------ | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------------ |
-| enabled                                         | boolean            | true          | Toggle the auto-configuration on/off                         | Only available with retryable-consumer-spring-boot-starter library |
-| topics                                          | Collection<String> | none          | Input consumer topic list                                    | Mandatory                                                          |
-| properties                                      | Properties         | none          | All standard Kafka Consumer configuration properties         | bootstrap.servers, key.deserializer, value.deserializer ...etc     |
-| pollBackoffMs                                   | Long               | 1000          | Timeout duration in ms for polling                           | Optional                                                           |
-| retryBackoffMs                                  | Long               | 0             | Circuit breaker backoff between each retry                   | Optional                                                           |
-| retryMax                                        | Long               | 0             | Circuit breaker max number of retry                          | Optional                                                           |
-| notRetryableExceptions                          | Collection<String> | empty list    | List of not retryable exception when retry option is enabled | Optional                                                           |
-| stopOnError                                     | boolean            | false         | Fully stop consumer on error                                 | Optional                                                           |
-
-Configuration key prefix`kafka.retryable.dead-letter.producer` :
-
-| Configuration key                               | Value Type         | Default Value | Description                                                  | Note                                                               |
-|-------------------------------------------------| ------------------ | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------------ |
-| topic                                           | String             | none          | Dead Letter Queue topic                                      |                                                                    |
-| kafka.retryable.dead-letter.producer.properties | Properties         | none          | All standard Kafka Producer configuration properties         | bootstrap.servers, key.serializer, value.serializer ...etc         |
-
-## Customization
 ### Dead Letter Queue (DLQ)
 
-The DLQ is optional and will only be created if `kafka.retryable.dead-letter.producer.topic` is configured. If configured, the DLQ producer requires producer properties including `bootstrap.servers` and serializers.
-
-Example DLQ config:
+The DLQ is optional. It is activated when `kafka.retryable.dead-letter.producer.topic` is configured along with producer properties.
 
 ```yaml
 kafka:
@@ -305,40 +210,56 @@ kafka:
       producer:
         topic: my-dlq
         properties:
-          bootstrap.servers: 127.0.0.1:9092
+          bootstrap.servers: localhost:9092
           key.serializer: org.apache.kafka.common.serialization.StringSerializer
           value.serializer: org.apache.kafka.common.serialization.StringSerializer
 ```
 
-If you don't set serializers for the DLQ producer, the starter will provide sensible defaults (StringSerializer) for tests and simple setups.
+### Custom Error Processing
 
-### Custom error processing
-If you need to build custom error processing (ex: log additional metrics, send alert, use a specific Dead Letter Queue format ...etc.),  
-you can implement `ErrorProcessor` interface :
+Implement the `ErrorProcessor` interface to add custom logic (metrics, alerts, custom DLQ format, etc.):
 
-```java  
-    @Slf4j
-    public class CustomErrorProcessor implements ErrorProcessor<ConsumerRecord<String, MyAvroObject>> {
-        @Override
-        public void processError(Throwable throwable, ConsumerRecord<String, MyAvroObject> record, Exception exception, int retryAttemptCount) {
-            // Your custom error processing here
-            log.error("...");
-        }
+```java
+@Slf4j
+public class CustomErrorProcessor implements ErrorProcessor<ConsumerRecord<String, MyAvroObject>> {
+    @Override
+    public void processError(Throwable throwable, ConsumerRecord<String, MyAvroObject> record,
+                             Exception exception, int retryAttemptCount) {
+        log.error("Custom error handling for record {}", record.key());
     }
-```  
+}
+```
 
-Then inject this custom error processor in your RetryableConsumer constructor :
-```java  
-    try(RetryableConsumer<String, MyAvroObject> retryableConsumer = new RetryableConsumer<>(
-            retryableConsumerConfiguration,
-            new CustomErrorProcessor()
-    )) {
-            retryableConsumer.listen(
-                Collections.singleton("MY_INPUT_TOPIC"),
-                myBusinessProcessService::processRecord
-            );
-    }  
-```  
+Then inject it into your consumer:
 
-# Code References
-This library relies on an original version from @jeanlouisboudart : https://github.com/jeanlouisboudart/retriable-consumer
+```java
+try (RetryableConsumer<String, MyAvroObject> retryableConsumer = new RetryableConsumer<>(
+        retryableConsumerConfiguration,
+        new CustomErrorProcessor()
+)) {
+    retryableConsumer.listen(
+        Collections.singleton("MY_INPUT_TOPIC"),
+        myBusinessProcessService::processRecord
+    );
+}
+```
+
+## Contribution & Development
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+```bash
+# Run all tests
+mvn clean test
+
+# Format code (required before submitting a PR)
+mvn spotless:apply
+```
+
+## License
+
+This project is licensed under the [Apache License 2.0](LICENSE).
+
+## Credits
+
+This library is inspired by the original work from [@jeanlouisboudart](https://github.com/jeanlouisboudart): [retriable-consumer](https://github.com/jeanlouisboudart/retriable-consumer).

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Configuration prefix: `kafka.retryable.dead-letter.producer`
 
 The library tracks consumer lifecycle state (`STARTING` -> `RUNNING` -> `ERROR` / `STOPPED`) and exposes Kubernetes-compatible health endpoints.
 
-**Spring Boot** — If `spring-boot-starter-web` is on the classpath, endpoints are auto-configured:
+**Spring Boot** — If `spring-boot-starter-web` is on the classpath, endpoints are autoconfigured:
 - `GET /{kubernetes.readiness.path}` (default: `/ready`)
 - `GET /{kubernetes.liveness.path}` (default: `/liveness`)
 

--- a/retryable-consumer-core/src/main/java/com/michelin/kafka/AbstractRetryableConsumer.java
+++ b/retryable-consumer-core/src/main/java/com/michelin/kafka/AbstractRetryableConsumer.java
@@ -74,6 +74,9 @@ public abstract class AbstractRetryableConsumer<K, V, P> implements Closeable {
     protected int retryCounter;
     protected boolean wakeUp;
 
+    @Getter
+    protected volatile ConsumerState consumerState = ConsumerState.STARTING;
+
     // ---- Constructors ----
 
     protected AbstractRetryableConsumer(String name) throws KafkaConfigurationException {
@@ -311,12 +314,17 @@ public abstract class AbstractRetryableConsumer<K, V, P> implements Closeable {
             ensureConsumer();
             consumer.subscribe(topics, this.rebalanceListener);
             this.retryCounter = 0;
+            this.consumerState = ConsumerState.RUNNING;
             while (!this.wakeUp) {
                 this.pollAndConsume(processor);
             }
         } catch (WakeupException e) {
             log.info("Wake up signal received. Getting out of the while loop", e);
+        } catch (Exception e) {
+            this.consumerState = ConsumerState.ERROR;
+            throw e;
         } finally {
+            this.consumerState = ConsumerState.STOPPED;
             consumer.close();
             log.info("Consumer is closed");
         }
@@ -452,6 +460,7 @@ public abstract class AbstractRetryableConsumer<K, V, P> implements Closeable {
             errorHandler.handleError(e, failedRecord);
 
             if (consumerConfig.getStopOnError()) {
+                this.consumerState = ConsumerState.ERROR;
                 log.error(
                         "Non-recoverable error occurred (Not retryable, or retry limit reached). Stopping consumer after 'stop-on-error' configuration...",
                         e);
@@ -474,6 +483,7 @@ public abstract class AbstractRetryableConsumer<K, V, P> implements Closeable {
         if (consumer != null) {
             consumer.wakeup();
             this.wakeUp = true;
+            this.consumerState = ConsumerState.STOPPED;
         }
     }
 

--- a/retryable-consumer-core/src/main/java/com/michelin/kafka/ConsumerState.java
+++ b/retryable-consumer-core/src/main/java/com/michelin/kafka/ConsumerState.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafka;
+
+/** Represents the lifecycle state of a retryable consumer. */
+public enum ConsumerState {
+    /** Consumer has been created but not yet started. */
+    STARTING,
+
+    /** Consumer is actively polling and processing records. */
+    RUNNING,
+
+    /** Consumer has encountered a fatal error. */
+    ERROR,
+
+    /** Consumer has been stopped. */
+    STOPPED
+}

--- a/retryable-consumer-core/src/main/java/com/michelin/kafka/service/KubernetesService.java
+++ b/retryable-consumer-core/src/main/java/com/michelin/kafka/service/KubernetesService.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafka.service;
+
+import com.michelin.kafka.AbstractRetryableConsumer;
+import com.michelin.kafka.ConsumerState;
+import java.net.HttpURLConnection;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Kubernetes health check service for the retryable consumer. Evaluates the consumer lifecycle state and returns
+ * appropriate HTTP status codes for readiness and liveness probes.
+ */
+@Slf4j
+public class KubernetesService {
+
+    public static final String READINESS_PATH_PROPERTY_NAME = "kubernetes.readiness.path";
+    public static final String LIVENESS_PATH_PROPERTY_NAME = "kubernetes.liveness.path";
+    public static final String DEFAULT_READINESS_PATH = "ready";
+    public static final String DEFAULT_LIVENESS_PATH = "liveness";
+
+    private final AbstractRetryableConsumer<?, ?, ?> consumer;
+
+    /**
+     * Constructor.
+     *
+     * @param consumer The retryable consumer instance
+     */
+    public KubernetesService(AbstractRetryableConsumer<?, ?, ?> consumer) {
+        this.consumer = consumer;
+    }
+
+    /**
+     * Kubernetes readiness probe. Returns:
+     *
+     * <ul>
+     *   <li>200 OK if consumer is RUNNING
+     *   <li>204 No Content if consumer is STARTING
+     *   <li>503 Service Unavailable if consumer is in ERROR or STOPPED
+     * </ul>
+     *
+     * @return An HTTP response code
+     */
+    public int getReadiness() {
+        if (consumer == null) {
+            return HttpURLConnection.HTTP_BAD_REQUEST;
+        }
+
+        ConsumerState state = consumer.getConsumerState();
+        log.debug("Consumer \"{}\" state: {}", consumer.getName(), state);
+
+        return switch (state) {
+            case RUNNING -> HttpURLConnection.HTTP_OK;
+            case STARTING -> HttpURLConnection.HTTP_NO_CONTENT;
+            case ERROR, STOPPED -> HttpURLConnection.HTTP_UNAVAILABLE;
+        };
+    }
+
+    /**
+     * Kubernetes liveness probe. Returns:
+     *
+     * <ul>
+     *   <li>200 OK if consumer is RUNNING or STARTING
+     *   <li>503 Service Unavailable if consumer is in ERROR or STOPPED
+     * </ul>
+     *
+     * @return An HTTP response code
+     */
+    public int getLiveness() {
+        if (consumer == null) {
+            return HttpURLConnection.HTTP_NO_CONTENT;
+        }
+
+        ConsumerState state = consumer.getConsumerState();
+
+        return switch (state) {
+            case RUNNING, STARTING -> HttpURLConnection.HTTP_OK;
+            case ERROR, STOPPED -> HttpURLConnection.HTTP_UNAVAILABLE;
+        };
+    }
+}

--- a/retryable-consumer-core/src/test/java/com/michelin/kafka/test/unit/KubernetesServiceTest.java
+++ b/retryable-consumer-core/src/test/java/com/michelin/kafka/test/unit/KubernetesServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafka.test.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.michelin.kafka.AbstractRetryableConsumer;
+import com.michelin.kafka.ConsumerState;
+import com.michelin.kafka.service.KubernetesService;
+import java.net.HttpURLConnection;
+import org.junit.jupiter.api.Test;
+
+class KubernetesServiceTest {
+
+    @Test
+    void shouldReturnOkWhenConsumerIsRunning() {
+        AbstractRetryableConsumer<?, ?, ?> consumer = mock(AbstractRetryableConsumer.class);
+        when(consumer.getConsumerState()).thenReturn(ConsumerState.RUNNING);
+        when(consumer.getName()).thenReturn("test-consumer");
+
+        KubernetesService service = new KubernetesService(consumer);
+
+        assertEquals(HttpURLConnection.HTTP_OK, service.getReadiness());
+        assertEquals(HttpURLConnection.HTTP_OK, service.getLiveness());
+    }
+
+    @Test
+    void shouldReturnNoContentWhenConsumerIsStarting() {
+        AbstractRetryableConsumer<?, ?, ?> consumer = mock(AbstractRetryableConsumer.class);
+        when(consumer.getConsumerState()).thenReturn(ConsumerState.STARTING);
+        when(consumer.getName()).thenReturn("test-consumer");
+
+        KubernetesService service = new KubernetesService(consumer);
+
+        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, service.getReadiness());
+        assertEquals(HttpURLConnection.HTTP_OK, service.getLiveness());
+    }
+
+    @Test
+    void shouldReturnUnavailableWhenConsumerIsInError() {
+        AbstractRetryableConsumer<?, ?, ?> consumer = mock(AbstractRetryableConsumer.class);
+        when(consumer.getConsumerState()).thenReturn(ConsumerState.ERROR);
+        when(consumer.getName()).thenReturn("test-consumer");
+
+        KubernetesService service = new KubernetesService(consumer);
+
+        assertEquals(HttpURLConnection.HTTP_UNAVAILABLE, service.getReadiness());
+        assertEquals(HttpURLConnection.HTTP_UNAVAILABLE, service.getLiveness());
+    }
+
+    @Test
+    void shouldReturnUnavailableWhenConsumerIsStopped() {
+        AbstractRetryableConsumer<?, ?, ?> consumer = mock(AbstractRetryableConsumer.class);
+        when(consumer.getConsumerState()).thenReturn(ConsumerState.STOPPED);
+        when(consumer.getName()).thenReturn("test-consumer");
+
+        KubernetesService service = new KubernetesService(consumer);
+
+        assertEquals(HttpURLConnection.HTTP_UNAVAILABLE, service.getReadiness());
+        assertEquals(HttpURLConnection.HTTP_UNAVAILABLE, service.getLiveness());
+    }
+
+    @Test
+    void shouldReturnBadRequestForReadinessWhenConsumerIsNull() {
+        KubernetesService service = new KubernetesService(null);
+
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, service.getReadiness());
+    }
+
+    @Test
+    void shouldReturnNoContentForLivenessWhenConsumerIsNull() {
+        KubernetesService service = new KubernetesService(null);
+
+        assertEquals(HttpURLConnection.HTTP_NO_CONTENT, service.getLiveness());
+    }
+}

--- a/retryable-consumer-core/src/test/java/com/michelin/kafka/test/unit/RetryableConsumerTest.java
+++ b/retryable-consumer-core/src/test/java/com/michelin/kafka/test/unit/RetryableConsumerTest.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -340,12 +341,10 @@ class RetryableConsumerTest {
 
             retryableConsumerCustomError.listenAsync(r -> recordProcessorNoError.processRecord(r));
             verify(kafkaConsumer, timeout(5000).atLeastOnce()).poll(any());
-            verify(customErrorProcessor, timeout(5000).times(1)).processError(any(), any(), any());
-
-            assertEquals(1, customErrorProcessor.getErrors().size());
+            ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
+            verify(customErrorProcessor, timeout(5000).times(1)).processError(throwableCaptor.capture(), any(), any());
             assertEquals(
-                    "Test Custom Error Processor",
-                    customErrorProcessor.getErrors().get(0));
+                    "Test Custom Error Processor", throwableCaptor.getValue().getMessage());
         }
     }
 

--- a/retryable-consumer-core/src/test/java/com/michelin/kafka/test/unit/RetryableConsumerTest.java
+++ b/retryable-consumer-core/src/test/java/com/michelin/kafka/test/unit/RetryableConsumerTest.java
@@ -310,7 +310,7 @@ class RetryableConsumerTest {
     @Test
     @Order(6)
     void testRetryableWithCustomErrorProcessor() throws Exception {
-        CustomErrorProcessor customErrorProcessor = new CustomErrorProcessor();
+        CustomErrorProcessor customErrorProcessor = spy(new CustomErrorProcessor());
         ConsumerRecord<String, String> record1 =
                 new ConsumerRecord<>(topic, record1Partition, record1Offset, "key1", "value1");
         ConsumerRecord<String, String> record2 =
@@ -340,6 +340,7 @@ class RetryableConsumerTest {
 
             retryableConsumerCustomError.listenAsync(r -> recordProcessorNoError.processRecord(r));
             verify(kafkaConsumer, timeout(5000).atLeastOnce()).poll(any());
+            verify(customErrorProcessor, timeout(5000).times(1)).processError(any(), any(), any());
 
             assertEquals(1, customErrorProcessor.getErrors().size());
             assertEquals(

--- a/retryable-consumer-spring-boot-starter/README.md
+++ b/retryable-consumer-spring-boot-starter/README.md
@@ -48,13 +48,14 @@ kubernetes:
 ```
 
 Status codes:
-| State      | Readiness | Liveness |
-|------------|-----------|----------|
-| RUNNING    | 200       | 200      |
-| STARTING   | 204       | 200      |
-| ERROR      | 503       | 503      |
-| STOPPED    | 503       | 503      |
-| null       | 400       | 204      |
+
+| State    | Readiness | Liveness |
+|----------|-----------|----------|
+| RUNNING  | 200       | 200      |
+| STARTING | 204       | 200      |
+| ERROR    | 503       | 503      |
+| STOPPED  | 503       | 503      |
+| null     | 400       | 204      |
 
 ## Advanced Usage
 - Provide your own `KafkaRetryableConfiguration` bean for full control

--- a/retryable-consumer-spring-boot-starter/README.md
+++ b/retryable-consumer-spring-boot-starter/README.md
@@ -1,5 +1,68 @@
 # Retryable Consumer Spring Boot Starter
 
-This module provides a Spring Boot autoconfiguration for the Retryable Consumer core library (retryable-consumer-core).
+Spring Boot autoconfiguration for [Kafka Retryable Consumer](../README.md).
 
-See top project README for an overview of the library and its features: [Retryable Consumer README](../README.md).
+## Features
+- Auto-configures `RetryableConsumer` as a Spring bean
+- Supports all core features (retry, DLQ, custom error processing)
+- **Kubernetes-style health check endpoints** (`/ready`, `/liveness`)
+- Minimal configuration required
+
+## Getting Started
+Add to your Spring Boot app:
+```xml
+<dependency>
+  <groupId>com.michelin.kafka</groupId>
+  <artifactId>retryable-consumer-spring-boot-starter</artifactId>
+  <version>${retryable-consumer-core.version}</version>
+</dependency>
+```
+
+Minimal `application.yml`:
+```yaml
+kafka:
+  retryable:
+    enabled: true
+    consumer:
+      topics:
+        - my-topic
+      properties:
+        bootstrap.servers: 127.0.0.1:9092
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+```
+
+## Health Check Endpoints
+
+If `spring-boot-starter-web` is present, the following endpoints are exposed:
+- `GET /ready` (readiness)
+- `GET /liveness` (liveness)
+
+You can override the paths:
+```yaml
+kubernetes:
+  readiness:
+    path: custom-ready
+  liveness:
+    path: custom-liveness
+```
+
+Status codes:
+| State      | Readiness | Liveness |
+|------------|-----------|----------|
+| RUNNING    | 200       | 200      |
+| STARTING   | 204       | 200      |
+| ERROR      | 503       | 503      |
+| STOPPED    | 503       | 503      |
+| null       | 400       | 204      |
+
+## Advanced Usage
+- Provide your own `KafkaRetryableConfiguration` bean for full control
+- Customize error handling by implementing `ErrorProcessor`
+- See [main README](../README.md) for core usage and customization
+
+## Contributing
+See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## License
+[Apache 2.0](../LICENSE)

--- a/retryable-consumer-spring-boot-starter/pom.xml
+++ b/retryable-consumer-spring-boot-starter/pom.xml
@@ -57,6 +57,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Spring Boot Web for health check endpoints -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test utilities: add spring-boot-test for ApplicationContextRunner and other test helpers -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/retryable-consumer-spring-boot-starter/src/main/java/com/michelin/kafka/autoconfigure/KafkaRetryableAutoConfiguration.java
+++ b/retryable-consumer-spring-boot-starter/src/main/java/com/michelin/kafka/autoconfigure/KafkaRetryableAutoConfiguration.java
@@ -21,9 +21,11 @@ package com.michelin.kafka.autoconfigure;
 import com.michelin.kafka.RetryableConsumer;
 import com.michelin.kafka.configuration.DeadLetterProducerConfiguration;
 import com.michelin.kafka.configuration.KafkaRetryableConfiguration;
+import com.michelin.kafka.controller.KubernetesController;
 import com.michelin.kafka.error.DeadLetterProducer;
 import com.michelin.kafka.mapper.KafkaRetryableConfigurationMapper;
 import com.michelin.kafka.properties.KafkaRetryableSpringProperties;
+import com.michelin.kafka.service.KubernetesService;
 import java.util.Properties;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -31,14 +33,17 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.lang.Nullable;
 
 @AutoConfiguration
 @EnableConfigurationProperties(KafkaRetryableSpringProperties.class)
 @ConditionalOnProperty(prefix = "kafka.retryable", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ComponentScan(basePackageClasses = KubernetesController.class)
 public class KafkaRetryableAutoConfiguration {
 
     @Bean
@@ -89,6 +94,13 @@ public class KafkaRetryableAutoConfiguration {
             return new RetryableConsumer<>(configuration, deadLetterProducer);
         }
         return new RetryableConsumer<>(configuration);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(KubernetesService.class)
+    @ConditionalOnWebApplication
+    public KubernetesService kubernetesService(RetryableConsumer<?, ?> retryableConsumer) {
+        return new KubernetesService(retryableConsumer);
     }
 
     private static Properties getConsumerProps(KafkaRetryableConfiguration configuration) {

--- a/retryable-consumer-spring-boot-starter/src/main/java/com/michelin/kafka/controller/KubernetesController.java
+++ b/retryable-consumer-spring-boot-starter/src/main/java/com/michelin/kafka/controller/KubernetesController.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kafka.controller;
+
+import com.michelin.kafka.service.KubernetesService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Kafka retryable consumer controller for Kubernetes health checks. Exposes readiness and liveness probe endpoints. */
+@RestController
+@ConditionalOnBean(KubernetesService.class)
+public class KubernetesController {
+
+    private final KubernetesService kubernetesService;
+
+    /**
+     * Constructor.
+     *
+     * @param kubernetesService The kubernetes service
+     */
+    public KubernetesController(KubernetesService kubernetesService) {
+        this.kubernetesService = kubernetesService;
+    }
+
+    /**
+     * Readiness Kubernetes probe endpoint.
+     *
+     * @return An HTTP response based on the consumer state
+     */
+    @GetMapping("/${kubernetes.readiness.path:ready}")
+    public ResponseEntity<Void> readiness() {
+        int readinessStatus = kubernetesService.getReadiness();
+        return ResponseEntity.status(readinessStatus).build();
+    }
+
+    /**
+     * Liveness Kubernetes probe endpoint.
+     *
+     * @return An HTTP response based on the consumer state
+     */
+    @GetMapping("/${kubernetes.liveness.path:liveness}")
+    public ResponseEntity<Void> liveness() {
+        int livenessStatus = kubernetesService.getLiveness();
+        return ResponseEntity.status(livenessStatus).build();
+    }
+}

--- a/retryable-consumer-spring-boot-starter/src/test/java/test/unit/KubernetesControllerTest.java
+++ b/retryable-consumer-spring-boot-starter/src/test/java/test/unit/KubernetesControllerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package test.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.michelin.kafka.controller.KubernetesController;
+import com.michelin.kafka.service.KubernetesService;
+import java.net.HttpURLConnection;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+class KubernetesControllerTest {
+
+    @Test
+    void shouldReturnReadinessStatus() {
+        KubernetesService kubernetesService = mock(KubernetesService.class);
+        when(kubernetesService.getReadiness()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        KubernetesController controller = new KubernetesController(kubernetesService);
+        ResponseEntity<Void> response = controller.readiness();
+
+        assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode().value());
+    }
+
+    @Test
+    void shouldReturnReadinessUnavailable() {
+        KubernetesService kubernetesService = mock(KubernetesService.class);
+        when(kubernetesService.getReadiness()).thenReturn(HttpURLConnection.HTTP_UNAVAILABLE);
+
+        KubernetesController controller = new KubernetesController(kubernetesService);
+        ResponseEntity<Void> response = controller.readiness();
+
+        assertEquals(
+                HttpURLConnection.HTTP_UNAVAILABLE, response.getStatusCode().value());
+    }
+
+    @Test
+    void shouldReturnLivenessStatus() {
+        KubernetesService kubernetesService = mock(KubernetesService.class);
+        when(kubernetesService.getLiveness()).thenReturn(HttpURLConnection.HTTP_OK);
+
+        KubernetesController controller = new KubernetesController(kubernetesService);
+        ResponseEntity<Void> response = controller.liveness();
+
+        assertEquals(HttpURLConnection.HTTP_OK, response.getStatusCode().value());
+    }
+
+    @Test
+    void shouldReturnLivenessUnavailable() {
+        KubernetesService kubernetesService = mock(KubernetesService.class);
+        when(kubernetesService.getLiveness()).thenReturn(HttpURLConnection.HTTP_UNAVAILABLE);
+
+        KubernetesController controller = new KubernetesController(kubernetesService);
+        ResponseEntity<Void> response = controller.liveness();
+
+        assertEquals(
+                HttpURLConnection.HTTP_UNAVAILABLE, response.getStatusCode().value());
+    }
+}

--- a/retryable-consumer-spring-boot-starter/src/test/java/test/unit/RetryableConsumerTest.java
+++ b/retryable-consumer-spring-boot-starter/src/test/java/test/unit/RetryableConsumerTest.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -339,12 +340,10 @@ class RetryableConsumerTest {
 
             retryableConsumerCustomError.listenAsync(r -> recordProcessorNoError.processRecord(r));
             verify(kafkaConsumer, timeout(5000).atLeastOnce()).poll(any());
-            verify(customErrorProcessor, timeout(5000).times(1)).processError(any(), any(), any());
-
-            assertEquals(1, customErrorProcessor.getErrors().size());
+            ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
+            verify(customErrorProcessor, timeout(5000).times(1)).processError(throwableCaptor.capture(), any(), any());
             assertEquals(
-                    "Test Custom Error Processor",
-                    customErrorProcessor.getErrors().get(0));
+                    "Test Custom Error Processor", throwableCaptor.getValue().getMessage());
         }
     }
 

--- a/retryable-consumer-spring-boot-starter/src/test/java/test/unit/RetryableConsumerTest.java
+++ b/retryable-consumer-spring-boot-starter/src/test/java/test/unit/RetryableConsumerTest.java
@@ -309,7 +309,7 @@ class RetryableConsumerTest {
     @Test
     @Order(6)
     void testRetryableWithCustomErrorProcessor() throws Exception {
-        CustomErrorProcessor customErrorProcessor = new CustomErrorProcessor();
+        CustomErrorProcessor customErrorProcessor = spy(new CustomErrorProcessor());
         ConsumerRecord<String, String> record1 =
                 new ConsumerRecord<>(topic, record1Partition, record1Offset, "key1", "value1");
         ConsumerRecord<String, String> record2 =
@@ -339,6 +339,7 @@ class RetryableConsumerTest {
 
             retryableConsumerCustomError.listenAsync(r -> recordProcessorNoError.processRecord(r));
             verify(kafkaConsumer, timeout(5000).atLeastOnce()).poll(any());
+            verify(customErrorProcessor, timeout(5000).times(1)).processError(any(), any(), any());
 
             assertEquals(1, customErrorProcessor.getErrors().size());
             assertEquals(


### PR DESCRIPTION
#12 
feat: Add Kubernetes health check endpoints (readiness & liveness)

Added ConsumerState enum (STARTING, RUNNING, ERROR, STOPPED) to track consumer lifecycle
Added state tracking to AbstractRetryableConsumer with transitions throughout the lifecycle
Added KubernetesService in core module with readiness/liveness logic returning appropriate HTTP status codes
Added KubernetesController in spring-boot-starter with GET /ready and GET /liveness endpoints (paths configurable via properties)
Auto-configure KubernetesService bean when a web application context is present
Added spring-boot-starter-web as optional dependency
Added unit tests for KubernetesService (6 tests) and KubernetesController (4 tests)
Updated README and spring-boot-starter README with health check documentation